### PR TITLE
dockerfile: move syntax directive to top of file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile-upstream:master
+
 # Copyright 2022 buildkit-syft-scanner authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,8 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# syntax=docker/dockerfile-upstream:master
 
 ARG GO_VERSION="1.19"
 ARG ALPINE_VERSION="3.17"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile-upstream:master
+# syntax=docker/dockerfile-upstream:1
 
 # Copyright 2022 buildkit-syft-scanner authors
 #


### PR DESCRIPTION
Directives are only recognized at the top of files, so need to be appear before the license preamble.