### PR TITLE
examples: add some basic examples to test on

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,76 @@
+name: e2e
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'master'
+    tags:
+      - 'v*'
+  pull_request:
+
+env:
+  BUILDX_VERSION: v0.10.0
+  BUILDKIT_IMAGE: moby/buildkit:v0.11.2
+  IMAGE_LOCAL: localhost:5000/buildkit-syft-scanner:latest
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        example:
+          - alpine
+          - centos
+          - ubuntu
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          version: ${{ env.BUILDX_VERSION }}
+          driver-opts: |
+            network=host
+            image=${{ env.BUILDKIT_IMAGE }}
+      -
+        name: Build and push Syft Scanner image
+        uses: docker/bake-action@v2
+        with:
+          targets: image-local
+          push: true
+      -
+        name: Test
+        uses: docker/build-push-action@v3
+        with:
+          context: ./examples
+          file: ./examples/${{ matrix.example }}.Dockerfile
+          sbom: generator=${{ env.IMAGE_LOCAL }}
+          outputs: /tmp/buildx-build
+      -
+        name: Check output folder
+        run: |
+          tree /tmp/buildx-build
+      -
+        name: Print SBOM
+        run: |
+          jq . /tmp/buildx-build/sbom-base.spdx.json
+      -
+        name: Upload output folder
+        uses: actions/upload-artifact@v3
+        with:
+          name: e2e-${{ matrix.example }}
+          path: /tmp/buildx-build/*
+          if-no-files-found: error

--- a/examples/alpine.Dockerfile
+++ b/examples/alpine.Dockerfile
@@ -1,0 +1,10 @@
+# syntax=docker/dockerfile:1.5
+
+FROM alpine AS base
+ARG BUILDKIT_SBOM_SCAN_STAGE=true
+RUN apk add git
+COPY <<EOF /empty
+EOF
+
+FROM scratch
+COPY --from=base /empty /

--- a/examples/alpine.Dockerfile
+++ b/examples/alpine.Dockerfile
@@ -1,5 +1,19 @@
 # syntax=docker/dockerfile:1.5
 
+# Copyright 2022 buildkit-syft-scanner authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FROM alpine AS base
 ARG BUILDKIT_SBOM_SCAN_STAGE=true
 RUN apk add git

--- a/examples/centos.Dockerfile
+++ b/examples/centos.Dockerfile
@@ -1,5 +1,19 @@
 # syntax=docker/dockerfile:1.5
 
+# Copyright 2022 buildkit-syft-scanner authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FROM centos:7
 ARG BUILDKIT_SBOM_SCAN_STAGE=true
 RUN yum install -y findutils

--- a/examples/centos.Dockerfile
+++ b/examples/centos.Dockerfile
@@ -1,0 +1,10 @@
+# syntax=docker/dockerfile:1.5
+
+FROM centos:7
+ARG BUILDKIT_SBOM_SCAN_STAGE=true
+RUN yum install -y findutils
+COPY <<EOF /empty
+EOF
+
+FROM scratch
+COPY --from=0 /empty /

--- a/examples/ubuntu.Dockerfile
+++ b/examples/ubuntu.Dockerfile
@@ -1,0 +1,10 @@
+# syntax=docker/dockerfile:1.5
+
+FROM ubuntu as base
+ARG BUILDKIT_SBOM_SCAN_STAGE=true
+RUN apt-get update && apt-get install -y git
+COPY <<EOF /empty
+EOF
+
+FROM scratch
+COPY --from=base /empty /

--- a/examples/ubuntu.Dockerfile
+++ b/examples/ubuntu.Dockerfile
@@ -1,5 +1,19 @@
 # syntax=docker/dockerfile:1.5
 
+# Copyright 2022 buildkit-syft-scanner authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FROM ubuntu as base
 ARG BUILDKIT_SBOM_SCAN_STAGE=true
 RUN apt-get update && apt-get install -y git


### PR DESCRIPTION
This is part of #26 - we should build these examples as part of the CI pipeline, and compare them to the results of `docker/buildkit-syft-scanner:edge` using a difftool, so we can easily see how syft has changed.

However, for now, it's useful to have the examples in-repo - so at least manual testing is somewhat consistent.