### PR TITLE
examples: modify go example to check for evidence relationship

### DIFF
--- a/examples/golang/checks/sbom-base.spdx.json
+++ b/examples/golang/checks/sbom-base.spdx.json
@@ -7,6 +7,11 @@
       {
         "name": "github.com/spf13/cobra"
       }
+    ],
+    "files": [
+      {
+        "fileName": "/app/app"
+      }
     ]
   }
 }

--- a/examples/golang/checks/sbom.spdx.json
+++ b/examples/golang/checks/sbom.spdx.json
@@ -5,7 +5,22 @@
     "SPDXID": "SPDXRef-DOCUMENT",
     "packages": [
       {
+        "SPDXID": "=package",
         "name": "github.com/spf13/cobra"
+      }
+    ],
+    "files": [
+      {
+        "SPDXID": "=filename",
+        "fileName": "/bin/app"
+      }
+    ],
+    "relationships": [
+      {
+        "spdxElementId": "==package",
+        "relationshipType": "OTHER",
+        "comment": "evident-by: indicates the package's existence is evident by the given file",
+        "relatedSpdxElement": "==filename"
       }
     ]
   }


### PR DESCRIPTION
Follow-up to #47, we should check for the new evidence relationships.