### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+*	@jedevc
+*	@cdupuis


### PR DESCRIPTION
I seem to regularly miss the opened PRs about updated syft versions - a good step to stop that from happening is just to have a CODEOWNERS file to get automatically notified.

@cdupuis I added you as well, let me know if that's alright!