### PR TITLE
gomod: update min go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/docker/buildkit-syft-scanner
 
-go 1.21.3
+go 1.21.0
 
 require (
 	github.com/anchore/go-logger v0.0.0-20230725134548-c21dafa1ec5a

--- a/hack/dockerfiles/vendor.Dockerfile
+++ b/hack/dockerfiles/vendor.Dockerfile
@@ -16,9 +16,10 @@
 
 # upstream at https://github.com/moby/buildkit/blob/master/hack/dockerfiles/vendor.Dockerfile
 
-ARG GO_VERSION=1.20
+ARG GO_VERSION="1.21"
+ARG ALPINE_VERSION="3.17"
 
-FROM golang:${GO_VERSION}-alpine AS base
+FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS base
 RUN apk add --no-cache git rsync
 WORKDIR /src
 


### PR DESCRIPTION
Don't think we require `1.21.3` as min go version, `1.21.0` should be enough. Also tried to set `1.21` but it seems tidy complains and expects a patch release `1.21.0`: https://github.com/docker/buildkit-syft-scanner/actions/runs/7232529430/job/19706797619#step:4:447

Not sure why in other projects like https://github.com/docker/buildx/blob/8484fcdd5715c0683e8605e05cdffc0bfa8fde94/go.mod#L3 it doesn't complain though :thinking:

Maybe something is cached on golang proxy?

Also add commit to align go version in vendor dockerfile.