### PR TITLE
Add sbom-cataloger, update to alpine 3.20 and Go 1.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG GO_VERSION="1.21"
-ARG ALPINE_VERSION="3.19"
+ARG GO_VERSION="1.23"
+ARG ALPINE_VERSION="3.20"
 ARG XX_VERSION="1.4.0"
 
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx
@@ -40,7 +40,7 @@ RUN --mount=target=. <<EOT
   echo "-extldflags -static -X ${pkg}/version.Version=${version} -X ${pkg}/version.SyftVersion=$(go list -mod=mod -u -m -f '{{.Version}}' 'github.com/anchore/syft')" | tee /tmp/.ldflags
 EOT
 
-FROM base as build
+FROM base AS build
 ARG TARGETPLATFORM
 RUN --mount=type=bind,target=. \
     --mount=type=bind,from=version,source=/tmp/.ldflags,target=/tmp/.ldflags \

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 variable "GO_VERSION" {
-  default = "1.21"
+  default = "1.23"
 }
 
 # GITHUB_REF is the actual ref that triggers the workflow and used as version

--- a/examples/custom-sbom/Dockerfile
+++ b/examples/custom-sbom/Dockerfile
@@ -14,17 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM centos:7 AS base
-
-# fix name of Centos repos as mirror.centos.org no longer exists
-RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/CentOS-*.repo
-RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/CentOS-*.repo
-RUN sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/CentOS-*.repo
-
+FROM alpine AS base
 ARG BUILDKIT_SBOM_SCAN_STAGE=true
-RUN yum install -y findutils
+RUN apk add git
 COPY <<EOF /empty
 EOF
 
 FROM scratch
-COPY --from=0 /empty /
+COPY --from=base /empty /
+
+COPY ./spdx.json /stuff.spdx.json

--- a/examples/custom-sbom/checks/sbom-base.spdx.json
+++ b/examples/custom-sbom/checks/sbom-base.spdx.json
@@ -1,0 +1,35 @@
+{
+  "_type": "https://in-toto.io/Statement/v0.1",
+  "predicateType": "https://spdx.dev/Document",
+  "subject": [
+    {
+      "name": "empty",
+      "digest": {
+        "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      }
+    }
+  ],
+  "predicate": {
+    "SPDXID": "SPDXRef-DOCUMENT",
+    "name": "sbom-base",
+    "packages": [
+      {
+        "SPDXID": "=package",
+        "name": "git"
+      }
+    ],
+    "files": [
+      {
+        "SPDXID": "=filename",
+        "fileName": "/usr/bin/git"
+      }
+    ],
+    "relationships": [
+      {
+        "spdxElementId": "==package",
+        "relationshipType": "CONTAINS",
+        "relatedSpdxElement": "==filename"
+      }
+    ]
+  }
+}

--- a/examples/custom-sbom/checks/sbom.spdx.json
+++ b/examples/custom-sbom/checks/sbom.spdx.json
@@ -1,0 +1,8 @@
+{
+  "_type": "https://in-toto.io/Statement/v0.1",
+  "predicateType": "https://spdx.dev/Document",
+  "predicate": {
+    "SPDXID": "SPDXRef-DOCUMENT",
+    "name": "sbom"
+  }
+}

--- a/examples/custom-sbom/spdx.json
+++ b/examples/custom-sbom/spdx.json
@@ -1,0 +1,47 @@
+{
+ "spdxVersion": "SPDX-2.3",
+ "dataLicense": "CC0-1.0",
+ "SPDXID": "SPDXRef-DOCUMENT",
+ "name": "localhost/syft3490",
+ "documentNamespace": "https://anchore.com/syft/image/localhost/syft3490-ca4ea7de-a4eb-4c91-8227-1335ee64325f",
+ "creationInfo": {
+  "licenseListVersion": "3.25",
+  "creators": [
+   "Organization: Anchore, Inc",
+   "Tool: syft-1.17.0"
+  ],
+  "created": "2024-12-04T15:45:17Z"
+ },
+ "packages": [
+  {
+   "name": "WILLL",
+   "SPDXID": "SPDXRef-Package-deb-adduser-0d50d654eb648ebd",
+   "versionInfo": "3.134",
+   "supplier": "NOASSERTION",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": true,
+   "packageVerificationCode": {
+    "packageVerificationCodeValue": "ee259e59ebc5bf49005492c1a393d32158491196"
+   },
+   "sourceInfo": "acquired package info from DPKG DB: /usr/share/doc/adduser/copyright, /var/lib/dpkg/info/adduser.conffiles, /var/lib/dpkg/info/adduser.list, /var/lib/dpkg/info/adduser.md5sums, /var/lib/dpkg/info/adduser.postrm, /var/lib/dpkg/info/adduser.preinst, /var/lib/dpkg/status",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "GPL-2.0-only AND GPL-2.0-or-later",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:adduser:adduser:3.134:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:deb/debian/adduser@3.134?arch=all&distro=debian-12"
+    }
+   ]
+  }
+ ],
+ "files": [],
+ "hasExtractedLicensingInfos": [],
+ "relationships": []
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/docker/buildkit-syft-scanner
 
-go 1.21.0
+go 1.23.0
 
 require (
 	github.com/anchore/go-logger v0.0.0-20230725134548-c21dafa1ec5a

--- a/hack/dockerfiles/license.Dockerfile
+++ b/hack/dockerfiles/license.Dockerfile
@@ -21,7 +21,7 @@ ARG ADDLICENSE_VERSION="v1.0.0"
 
 FROM ghcr.io/google/addlicense:${ADDLICENSE_VERSION} AS addlicense
 
-FROM alpine:3.16 AS base
+FROM alpine:3.20 AS base
 WORKDIR /src
 RUN apk add --no-cache cpio findutils git
 

--- a/hack/dockerfiles/vendor.Dockerfile
+++ b/hack/dockerfiles/vendor.Dockerfile
@@ -16,8 +16,8 @@
 
 # upstream at https://github.com/moby/buildkit/blob/master/hack/dockerfiles/vendor.Dockerfile
 
-ARG GO_VERSION="1.21"
-ARG ALPINE_VERSION="3.17"
+ARG GO_VERSION="1.23"
+ARG ALPINE_VERSION="3.20"
 
 FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS base
 RUN apk add --no-cache git rsync

--- a/internal/target.go
+++ b/internal/target.go
@@ -46,7 +46,7 @@ func (t Target) Scan() (sbom.SBOM, error) {
 		return sbom.SBOM{}, fmt.Errorf("failed to create source from %q: %w", t.Path, err)
 	}
 
-	result, err := syft.CreateSBOM(context.Background(), src, syft.DefaultCreateSBOMConfig().WithCatalogerSelection(pkgcataloging.NewSelectionRequest().WithDefaults(pkgcataloging.ImageTag)))
+	result, err := syft.CreateSBOM(context.Background(), src, syft.DefaultCreateSBOMConfig().WithCatalogerSelection(pkgcataloging.NewSelectionRequest().WithDefaults(pkgcataloging.ImageTag).WithAdditions("sbom-cataloger")))
 	if err != nil {
 		return sbom.SBOM{}, err
 	}


### PR DESCRIPTION
PR to fix the issue described in https://github.com/docker/buildkit-syft-scanner/issues/111 

Notes:
- Cannot be built on MacoS due to case-insensitive filesystem (Microsoft dependencies use upper and lower case (rustaudit))
- Created custom-sbom example but not convinced that check command performs any meaningful validation
- Other libraries may still be out of date
- Alpine 3.21 appears to cause the xx-* helpers to fail due to an issue with /var/log/xx-verify. 3.20 works
- Added some changes to centos as mirror is no longer available due to Centos 7 being EOL