### PR TITLE
ci: remove mode=max on cache export

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,7 +67,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           set: |
             *.cache-from=type=gha,scope=image
-            *.cache-to=type=gha,scope=image,mode=max
+            *.cache-to=type=gha,scope=image
             *.attest=type=sbom
 
   dockerhub-readme:


### PR DESCRIPTION
Cache `mode=max` slows down the build and is not really necessary.