### PR TITLE
ci: fix e2e workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,7 +15,7 @@ on:
 
 env:
   BUILDX_VERSION: latest
-  BUILDKIT_IMAGE: moby/buildkit:latest
+  BUILDKIT_IMAGE: moby/buildkit:v0.22.0 # FIXME: Update to the latest version once https://github.com/moby/buildkit/issues/6049 is fixed
   IMAGE_LOCAL: localhost:5000/buildkit-syft-scanner:latest
 
 jobs:


### PR DESCRIPTION
fixes https://github.com/moby/buildkit/issues/6049

Use previous BuildKit stable in e2e workflow as workaround for regression in BuildKit v0.23.0: https://github.com/moby/buildkit/issues/6049