### PR TITLE
set file tag explicitly to suppress warning

### DIFF
--- a/internal/target.go
+++ b/internal/target.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/anchore/syft/syft"
+	"github.com/anchore/syft/syft/cataloging/filecataloging"
 	"github.com/anchore/syft/syft/cataloging/pkgcataloging"
 	"github.com/anchore/syft/syft/sbom"
 	"github.com/anchore/syft/syft/source"
@@ -46,8 +47,13 @@ func (t Target) Scan(ctx context.Context) (sbom.SBOM, error) {
 	}
 
 	sr := pkgcataloging.NewSelectionRequest().
-		WithDefaults(pkgcataloging.ImageTag).
-		WithAdditions("sbom-cataloger")
+		WithDefaults(
+			pkgcataloging.ImageTag,
+			filecataloging.FileTag, // https://github.com/anchore/syft/pull/3505
+		).
+		WithAdditions(
+			"sbom-cataloger",
+		)
 
 	if v, ok := os.LookupEnv("BUILDKIT_SCAN_SELECT_CATALOGERS"); ok {
 		sr = pkgcataloging.NewSelectionRequest().WithExpression(strings.Split(v, ",")...)


### PR DESCRIPTION
related to https://github.com/anchore/syft/pull/3505

https://github.com/docker/buildkit-syft-scanner/actions/runs/15877576651/job/44768951586#step:7:87

```
#15 [linux/amd64] generating sbom using localhost:5000/buildkit-syft-scanner:latest
#15 0.060 time="2025-06-25T13:25:09Z" level=info msg="starting syft scanner for buildkit c568c12"
#15 0.062 [0000]  WARN adding 'file' tag to the default cataloger selection, to override add '-file' to the cataloger selection request
#15 0.868 [0000]  WARN adding 'file' tag to the default cataloger selection, to override add '-file' to the cataloger selection request
#15 DONE 1.8s
```