### PR TITLE
ci: checkout full history

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,8 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -55,6 +55,8 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       -
         uses: actions/setup-go@v5
         with:
@@ -71,6 +73,7 @@ jobs:
         name: Build and push Syft Scanner image
         uses: docker/bake-action@v6
         with:
+          source: .
           targets: image-local
           push: true
       -


### PR DESCRIPTION
`version.Version` is not correct on edge: https://github.com/docker/buildkit-syft-scanner/actions/runs/15901949571/job/44846827442#step:7:513

```
 #22 [linux/amd64->arm64 build 1/1] RUN --mount=type=bind,target=.     --mount=type=bind,from=version,source=/tmp/.ldflags,target=/tmp/.ldflags     --mount=type=cache,target=/root/.cache <<EOT (set -ex...)
#22 0.093 + xx-go version
#22 0.105 go version go1.24.4 linux/amd64
#22 0.107 + cat /tmp/.ldflags
#22 0.108 + xx-go build -trimpath -ldflags '-extldflags -static -X github.com/docker/buildkit-syft-scanner/version.Version=ffb8283 -X github.com/docker/buildkit-syft-scanner/version.SyftVersion=v1.27.1' -o /usr/local/bin/syft-scanner ./cmd/syft-scanner
#22 ...
```