### PR TITLE
emit in-toto v1 SBOM statements

### DIFF
--- a/examples/alpine/checks/sbom-base.spdx.json
+++ b/examples/alpine/checks/sbom-base.spdx.json
@@ -1,5 +1,5 @@
 {
-  "_type": "https://in-toto.io/Statement/v0.1",
+  "_type": "https://in-toto.io/Statement/v1",
   "predicateType": "https://spdx.dev/Document",
   "subject": [
     {

--- a/examples/alpine/checks/sbom.spdx.json
+++ b/examples/alpine/checks/sbom.spdx.json
@@ -1,5 +1,5 @@
 {
-  "_type": "https://in-toto.io/Statement/v0.1",
+  "_type": "https://in-toto.io/Statement/v1",
   "predicateType": "https://spdx.dev/Document",
   "predicate": {
     "SPDXID": "SPDXRef-DOCUMENT",

--- a/examples/amazonlinux/checks/sbom-base.spdx.json
+++ b/examples/amazonlinux/checks/sbom-base.spdx.json
@@ -1,5 +1,5 @@
 {
-  "_type": "https://in-toto.io/Statement/v0.1",
+  "_type": "https://in-toto.io/Statement/v1",
   "predicateType": "https://spdx.dev/Document",
   "subject": [
     {

--- a/examples/amazonlinux/checks/sbom.spdx.json
+++ b/examples/amazonlinux/checks/sbom.spdx.json
@@ -1,5 +1,5 @@
 {
-  "_type": "https://in-toto.io/Statement/v0.1",
+  "_type": "https://in-toto.io/Statement/v1",
   "predicateType": "https://spdx.dev/Document",
   "predicate": {
     "SPDXID": "SPDXRef-DOCUMENT",

--- a/examples/centos/checks/sbom-base.spdx.json
+++ b/examples/centos/checks/sbom-base.spdx.json
@@ -1,5 +1,5 @@
 {
-  "_type": "https://in-toto.io/Statement/v0.1",
+  "_type": "https://in-toto.io/Statement/v1",
   "predicateType": "https://spdx.dev/Document",
   "subject": [
     {

--- a/examples/centos/checks/sbom.spdx.json
+++ b/examples/centos/checks/sbom.spdx.json
@@ -1,5 +1,5 @@
 {
-  "_type": "https://in-toto.io/Statement/v0.1",
+  "_type": "https://in-toto.io/Statement/v1",
   "predicateType": "https://spdx.dev/Document",
   "predicate": {
     "SPDXID": "SPDXRef-DOCUMENT",

--- a/examples/golang/checks/sbom-base.spdx.json
+++ b/examples/golang/checks/sbom-base.spdx.json
@@ -1,5 +1,5 @@
 {
-  "_type": "https://in-toto.io/Statement/v0.1",
+  "_type": "https://in-toto.io/Statement/v1",
   "predicateType": "https://spdx.dev/Document",
   "subject": [
     {

--- a/examples/golang/checks/sbom.spdx.json
+++ b/examples/golang/checks/sbom.spdx.json
@@ -1,5 +1,5 @@
 {
-  "_type": "https://in-toto.io/Statement/v0.1",
+  "_type": "https://in-toto.io/Statement/v1",
   "predicateType": "https://spdx.dev/Document",
   "predicate": {
     "SPDXID": "SPDXRef-DOCUMENT",

--- a/examples/npm-lock/checks/sbom-base.spdx.json
+++ b/examples/npm-lock/checks/sbom-base.spdx.json
@@ -1,5 +1,5 @@
 {
-  "_type": "https://in-toto.io/Statement/v0.1",
+  "_type": "https://in-toto.io/Statement/v1",
   "predicateType": "https://spdx.dev/Document",
   "predicate": {
     "SPDXID": "SPDXRef-DOCUMENT",

--- a/examples/npm-lock/checks/sbom.spdx.json
+++ b/examples/npm-lock/checks/sbom.spdx.json
@@ -1,5 +1,5 @@
 {
-  "_type": "https://in-toto.io/Statement/v0.1",
+  "_type": "https://in-toto.io/Statement/v1",
   "predicateType": "https://spdx.dev/Document",
   "predicate": {
     "SPDXID": "SPDXRef-DOCUMENT",

--- a/examples/sbom-cataloger/checks/sbom-base.spdx.json
+++ b/examples/sbom-cataloger/checks/sbom-base.spdx.json
@@ -1,5 +1,5 @@
 {
-  "_type": "https://in-toto.io/Statement/v0.1",
+  "_type": "https://in-toto.io/Statement/v1",
   "predicateType": "https://spdx.dev/Document",
   "subject": [
     {

--- a/examples/sbom-cataloger/checks/sbom.spdx.json
+++ b/examples/sbom-cataloger/checks/sbom.spdx.json
@@ -1,5 +1,5 @@
 {
-  "_type": "https://in-toto.io/Statement/v0.1",
+  "_type": "https://in-toto.io/Statement/v1",
   "predicateType": "https://spdx.dev/Document",
   "predicate": {
     "SPDXID": "SPDXRef-DOCUMENT",

--- a/examples/scratch/checks/sbom.spdx.json
+++ b/examples/scratch/checks/sbom.spdx.json
@@ -1,5 +1,5 @@
 {
-  "_type": "https://in-toto.io/Statement/v0.1",
+  "_type": "https://in-toto.io/Statement/v1",
   "predicateType": "https://spdx.dev/Document",
   "predicate": {
     "SPDXID": "SPDXRef-DOCUMENT",

--- a/examples/ubuntu/checks/sbom-base.spdx.json
+++ b/examples/ubuntu/checks/sbom-base.spdx.json
@@ -1,5 +1,5 @@
 {
-  "_type": "https://in-toto.io/Statement/v0.1",
+  "_type": "https://in-toto.io/Statement/v1",
   "predicateType": "https://spdx.dev/Document",
   "subject": [
     {

--- a/examples/ubuntu/checks/sbom.spdx.json
+++ b/examples/ubuntu/checks/sbom.spdx.json
@@ -1,5 +1,5 @@
 {
-  "_type": "https://in-toto.io/Statement/v0.1",
+  "_type": "https://in-toto.io/Statement/v1",
   "predicateType": "https://spdx.dev/Document",
   "predicate": {
     "SPDXID": "SPDXRef-DOCUMENT",

--- a/internal/scanner.go
+++ b/internal/scanner.go
@@ -50,7 +50,7 @@ func (s Scanner) Scan(ctx context.Context) error {
 		}
 		stmt := intoto.Statement{
 			StatementHeader: intoto.StatementHeader{
-				Type:          intoto.StatementInTotoV01,
+				Type:          intoto.StatementInTotoV1,
 				PredicateType: intoto.PredicateSPDX,
 			},
 			Predicate: json.RawMessage(output),


### PR DESCRIPTION
follow-up https://github.com/moby/buildkit/pull/6823

also fixes golden files related to https://github.com/docker/buildkit-syft-scanner/actions/runs/28634255993/job/84917275885#step:7:89

```
#16 exporting to client directory
#16 copying files 206.24kB 0.0s done
#16 DONE 0.0s
[-] Checking example alpine...
  [-] Checking schema ./examples/alpine/checks/sbom-base.spdx.json...
value mismatch on ._type, expected https://in-toto.io/Statement/v0.1, got https://in-toto.io/Statement/v1
exit status 1

```