### PR TITLE
internal/scanner: scope output file cleanup

### DIFF
--- a/internal/scanner.go
+++ b/internal/scanner.go
@@ -57,14 +57,18 @@ func (s Scanner) Scan(ctx context.Context) error {
 		}
 
 		outputPath := filepath.Join(s.Destination, target.Name()+".spdx.json")
-		f, err := os.Create(outputPath)
-		if err != nil {
-			return err
-		}
-		if err := json.NewEncoder(f).Encode(stmt); err != nil {
-			return err
-		}
-		if err := f.Close(); err != nil {
+		if err := func() (retErr error) {
+			f, err := os.Create(outputPath)
+			if err != nil {
+				return err
+			}
+			defer func() {
+				if err := f.Close(); retErr == nil && err != nil {
+					retErr = err
+				}
+			}()
+			return json.NewEncoder(f).Encode(stmt)
+		}(); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
closes #184 

Wrap each output write in a small scoped function so the deferred close runs before the next target is scanned. This keeps close errors visible on successful encodes while ensuring encode failures do not leave the output file open.